### PR TITLE
exclude deprecated "GitHub Sales Professional" certificate

### DIFF
--- a/fetch_country.py
+++ b/fetch_country.py
@@ -25,6 +25,10 @@ ALLOWED_MICROSOFT_GITHUB_CERTIFICATIONS = {
     'Microsoft Applied Skills: Automate Azure Load Testing by using GitHub Actions',
 }
 
+EXCLUDED_GITHUB_CERTIFICATIONS = {
+    'GitHub Sales Professional',
+}
+
 def is_badge_expired(expires_at_date):
     """Check if a badge is expired based on expires_at_date"""
     if not expires_at_date:  # null = never expires
@@ -104,7 +108,7 @@ def fetch_github_org_badges(user_id):
                         # Get badge name and only count if unique
                         badge_template = badge.get('badge_template', {})
                         badge_name = badge_template.get('name', '')
-                        if badge_name:
+                        if badge_name and badge_name not in EXCLUDED_GITHUB_CERTIFICATIONS:
                             unique_badge_names.add(badge_name)
             
             page += 1

--- a/fetch_large_country.py
+++ b/fetch_large_country.py
@@ -23,6 +23,10 @@ ALLOWED_MICROSOFT_GITHUB_CERTIFICATIONS = {
     'Microsoft Applied Skills: Automate Azure Load Testing by using GitHub Actions',
 }
 
+EXCLUDED_GITHUB_CERTIFICATIONS = {
+    'GitHub Sales Professional',
+}
+
 def is_badge_expired(expires_at_date):
     """Check if a badge is expired based on expires_at_date"""
     if not expires_at_date:  # null = never expires
@@ -102,7 +106,7 @@ def fetch_github_org_badges(user_id):
                         # Get badge name and only count if unique
                         badge_template = badge.get('badge_template', {})
                         badge_name = badge_template.get('name', '')
-                        if badge_name:
+                        if badge_name and badge_name not in EXCLUDED_GITHUB_CERTIFICATIONS:
                             unique_badge_names.add(badge_name)
             
             page += 1


### PR DESCRIPTION
Currently, the "GitHub Sales Professional" certificate is being counted towards certification totals.

That certification is no longer offered and has been replaced by "FY26 GitHub Partner Sales Professional." Thus, it should be removed from the tally.


Related: https://github.com/andrediasbr/github-certification-ranking/issues/8 