### PR TITLE
Fix typo in certification name for GitHub secret scanning and add GitHub Certified: Agentic AI Developer certificate

### DIFF
--- a/certifications.py
+++ b/certifications.py
@@ -75,7 +75,7 @@ ALLOWED_MICROSOFT_GITHUB_CERTIFICATIONS = {
     'Microsoft Applied Skills: Accelerate app development by using GitHub Copilot',
     'Microsoft Applied Skills: Automate Azure Load Testing by using GitHub Actions',
     'Microsoft Applied Skills: Resolve GitHub issues by using GitHub Copilot',
-    'Microsoft Applied Skills: Manage GitHub secret scanning with GitHub Copilot',
+    'Microsoft Applied Skills: Manage GitHub secret scanning by using GitHub Copilot',
 }
 
 # Map of renamed/duplicate badges to their canonical name.

--- a/certifications.py
+++ b/certifications.py
@@ -70,6 +70,7 @@ ALLOWED_MICROSOFT_GITHUB_CERTIFICATIONS = {
     'GitHub Advanced Security',
     'GitHub Foundations',
     'GitHub Administration',
+    'Developing in Agentic AI Systems',
     'Microsoft Certified: DevOps Engineer Expert',
     'Microsoft Applied Skills: Accelerate AI-assisted development by using GitHub Copilot',
     'Microsoft Applied Skills: Accelerate app development by using GitHub Copilot',

--- a/certifications.py
+++ b/certifications.py
@@ -70,7 +70,7 @@ ALLOWED_MICROSOFT_GITHUB_CERTIFICATIONS = {
     'GitHub Advanced Security',
     'GitHub Foundations',
     'GitHub Administration',
-    'Developing in Agentic AI Systems',
+    'GitHub Certified: Agentic AI Developer',
     'Microsoft Certified: DevOps Engineer Expert',
     'Microsoft Applied Skills: Accelerate AI-assisted development by using GitHub Copilot',
     'Microsoft Applied Skills: Accelerate app development by using GitHub Copilot',


### PR DESCRIPTION
This pull request makes a small update to the list of recognized certifications in `certifications.py`. The main changes are the addition of a new certification and a correction to an existing certification name.

Certification additions:

* Added `'GitHub Certified: Agentic AI Developer'` to the list of certifications.

Certification name correction:

* Changed the certification name from `'Microsoft Applied Skills: Manage GitHub secret scanning with GitHub Copilot'` to `'Microsoft Applied Skills: Manage GitHub secret scanning by using GitHub Copilot'` in the set of recognized certifications.